### PR TITLE
Add REST client for MIT operations

### DIFF
--- a/sermepa/__init__.py
+++ b/sermepa/__init__.py
@@ -381,11 +381,8 @@ class RestClient(Client):
         encoded = response_data.get('Ds_MerchantParameters')
         if not encoded:
             return None
-        try:
-            decoded = base64.urlsafe_b64decode(b(encoded))
-            return json.loads(decoded)
-        except Exception:
-            return None
+        decoded = base64.urlsafe_b64decode(b(encoded))
+        return json.loads(decoded)
 
     def mit_payment(self, transaction_params):
         signed_data = encodeSignedData(self.priv_key, **transaction_params)

--- a/sermepa/__init__.py
+++ b/sermepa/__init__.py
@@ -13,6 +13,7 @@ import base64
 import hmac
 import json
 import pyDes
+import requests
 
 # Python 3 compatibility
 try:
@@ -66,6 +67,16 @@ _request_fields = [
         # Representa la fecha de la cuota sucesiva, necesaria para identificar la transacción en las devoluciones.  Obligatorio en las devoluciones de cuotas sucesivas y de cuotas sucesivas diferidas.
     ('O','A',   4, 'Ds_Merchant_PayMethods'),
         # Payment method, z for bizum, C for credit card, P for PayPal, R for transference, xpay for GooglePay and ApplePay
+    ('O','A',  40, 'Ds_Merchant_Identifier'),
+        # Token/identifier for COF/MIT operations.
+    ('O','A',   1, 'Ds_Merchant_Cof_INI'),
+        # S for initial COF operation, N for subsequent operation.
+    ('O','A',   1, 'Ds_Merchant_Cof_Type'),
+        # COF type, C for MIT/Otras in common setups.
+    ('O','A',  10, 'Ds_Merchant_Excep_SCA'),
+        # SCA exception hint (e.g. MIT).
+    ('O','A',   5, 'Ds_Merchant_DirectPayment'),
+        # Direct payment hint for token-based operations.
 
 ]
 
@@ -355,6 +366,42 @@ class Client(object):
 #            'Ds_Merchant_AuthorisationCode': self.Ds_Merchant_AuthorisationCode,
 #            'Ds_Merchant_TransactionDate': self.Ds_Merchant_TransactionDate,
             })
+
+
+class RestClient(Client):
+    """REST Client for Redsys operations."""
+
+    def __init__(self, business_code, priv_key,
+                 endpoint_url='https://sis.redsys.es/sis/rest/trataPeticionREST',
+                 timeout=30):
+        super(RestClient, self).__init__(business_code, priv_key, endpoint_url)
+        self.timeout = timeout
+
+    def _decode_response_parameters(self, response_data):
+        encoded = response_data.get('Ds_MerchantParameters')
+        if not encoded:
+            return None
+        try:
+            decoded = base64.urlsafe_b64decode(b(encoded))
+            return json.loads(decoded)
+        except Exception:
+            return None
+
+    def mit_payment(self, transaction_params):
+        signed_data = encodeSignedData(self.priv_key, **transaction_params)
+
+        response = requests.post(
+            self.endpoint,
+            json=signed_data,
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+
+        response_data = response.json()
+        return dict(
+            raw=response_data,
+            merchant_parameters=self._decode_response_parameters(response_data),
+        )
 
 
 class TestClient(Client):

--- a/sermepa/sermepa_test.py
+++ b/sermepa/sermepa_test.py
@@ -14,8 +14,18 @@ from sermepa import (
     decodeSignedData,
     encodeSignedData,
     SignatureError,
+    RestClient,
     u, b,
 )
+
+try:
+    from unittest.mock import patch, Mock
+except ImportError:
+    try:
+        from mock import patch, Mock
+    except ImportError:
+        patch = None
+        Mock = None
 
 try:
     import config
@@ -542,6 +552,77 @@ class NotificationReceiver_Test(unittest.TestCase):
             "Ds_ErrorCode":"SIS0093",
             "Ds_AuthorisationCode":"++++++",
             }
+
+
+class RestClient_Test(unittest.TestCase):
+
+    merchantkey = 'sq7HjrUOBfKmC576ILgskD5srU870gJ7'
+
+    def test_encodeSignedData_accepts_mit_fields(self):
+        result = encodeSignedData(
+            self.merchantkey,
+            Ds_Merchant_Amount='145',
+            Ds_Merchant_Order='1447961844',
+            Ds_Merchant_MerchantCode='999008881',
+            Ds_Merchant_Currency='978',
+            Ds_Merchant_TransactionType='O',
+            Ds_Merchant_Terminal='1',
+            Ds_Merchant_MerchantURL='https://merchant.local/notify',
+            Ds_Merchant_SumTotal='145',
+            Ds_Merchant_UrlOK='https://merchant.local/ok',
+            Ds_Merchant_UrlKO='https://merchant.local/ko',
+            Ds_Merchant_Identifier='TOKEN123',
+            Ds_Merchant_Cof_INI='N',
+            Ds_Merchant_Cof_Type='C',
+            Ds_Merchant_Excep_SCA='MIT',
+            Ds_Merchant_DirectPayment='true',
+        )
+
+        self.assertIn('Ds_MerchantParameters', result)
+        payload = json.loads(base64.b64decode(result['Ds_MerchantParameters']))
+        self.assertEqual(payload['Ds_Merchant_Identifier'], 'TOKEN123')
+        self.assertEqual(payload['Ds_Merchant_Cof_Type'], 'C')
+
+    @unittest.skipIf(patch is None, 'mock package not available')
+    @patch('sermepa.requests.post')
+    def test_mit_payment_calls_rest_endpoint(self, post_mock):
+        client = RestClient('999008881', self.merchantkey)
+        response_payload = {'Ds_Response': '0000'}
+        encoded = base64.urlsafe_b64encode(b(json.dumps(response_payload)))
+
+        response = Mock()
+        response.json.return_value = {
+            'Ds_SignatureVersion': 'HMAC_SHA256_V1',
+            'Ds_Signature': 'signature',
+            'Ds_MerchantParameters': u(encoded),
+        }
+        response.raise_for_status.return_value = None
+        post_mock.return_value = response
+
+        tx = dict(
+            Ds_Merchant_Amount='145',
+            Ds_Merchant_Order='1447961844',
+            Ds_Merchant_MerchantCode='999008881',
+            Ds_Merchant_Currency='978',
+            Ds_Merchant_TransactionType='O',
+            Ds_Merchant_Terminal='1',
+            Ds_Merchant_MerchantURL='https://merchant.local/notify',
+            Ds_Merchant_SumTotal='145',
+            Ds_Merchant_UrlOK='https://merchant.local/ok',
+            Ds_Merchant_UrlKO='https://merchant.local/ko',
+            Ds_Merchant_Identifier='TOKEN123',
+            Ds_Merchant_Cof_INI='N',
+            Ds_Merchant_Cof_Type='C',
+            Ds_Merchant_Excep_SCA='MIT',
+            Ds_Merchant_DirectPayment='true',
+        )
+        result = client.mit_payment(tx)
+
+        post_mock.assert_called_once()
+        call_kwargs = post_mock.call_args[1]
+        self.assertEqual(call_kwargs['timeout'], 30)
+        self.assertIn('Ds_MerchantParameters', call_kwargs['json'])
+        self.assertEqual(result['merchant_parameters']['Ds_Response'], '0000')
 
 
 


### PR DESCRIPTION
## Description

Afegeix la possibilitat de fer un get_pay_form_data per iniciar una MIT operation (tokenització) i després poder fer crides REST de pagament sense intervenció del client